### PR TITLE
First draft of prediction type

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -221,6 +221,28 @@ message TripUpdate {
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
 
+    // Experimental feild, subject to change
+    // PredictionType represent the source of data of the prediction 
+    // This lets consumer know if they should display a 
+    // real time symbol next to a departure and the type of prediction 
+    // PredictionType is ignored when schedule_relationship = SKIPPED or NO_DATA
+    enum PredictionType {
+      // Update are based on information from a vehicle 
+      // that is followed in real time
+      // This is the default
+      REALTIME = 0;
+
+      // Update are based on information from a vehicle that was followed 
+      // in real time but is imprecise. Imprecision can come from things like 
+      // a bus losing internet connection after the start of the run.
+      IMPRECISE_REALTIME = 1;
+
+      // Update are based on information from schedule but improved 
+      // from what is present in the static GTFS
+      IMPROVED_SCHEDULE = 2;
+    }
+    optional PredictionType prediction_type = 6 [default = REALTIME]
+
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -234,7 +234,7 @@ message TripUpdate {
 
       // Update are based on information from a vehicle that was followed
       // in real time but is imprecise. Imprecision can come from things like
-      // a bus losing internet connection after the start of the run.
+      // a bus losing connection after the start of the run.
       IMPRECISE_REALTIME = 1;
 
       // Update are based on information from schedule but updated

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -222,24 +222,24 @@ message TripUpdate {
         [default = SCHEDULED];
 
     // Experimental feild, subject to change
-    // PredictionType represent the source of data of the prediction 
-    // This lets consumer know if they should display a 
-    // real time symbol next to a departure and the type of prediction 
+    // PredictionType represent the source of data of the prediction
+    // This lets consumer know if they should display a
+    // real time symbol next to a departure and the type of prediction
     // PredictionType is ignored when schedule_relationship = SKIPPED or NO_DATA
     enum PredictionType {
-      // Update are based on information from a vehicle 
+      // Update are based on information from a vehicle
       // that is followed in real time
       // This is the default
       REALTIME = 0;
 
-      // Update are based on information from a vehicle that was followed 
-      // in real time but is imprecise. Imprecision can come from things like 
+      // Update are based on information from a vehicle that was followed
+      // in real time but is imprecise. Imprecision can come from things like
       // a bus losing internet connection after the start of the run.
       IMPRECISE_REALTIME = 1;
 
-      // Update are based on information from schedule but improved 
-      // from what is present in the static GTFS
-      IMPROVED_SCHEDULE = 2;
+      // Update are based on information from schedule but updated
+      // from what is present in the static GTFS due to control actions.
+      UPDATED_SCHEDULE = 2;
     }
     optional PredictionType prediction_type = 6 [default = REALTIME]
 

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -221,7 +221,7 @@ message TripUpdate {
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
 
-    // Experimental feild, subject to change
+    // Experimental field, subject to change
     // PredictionType represent the source of data of the prediction
     // This lets consumer know if they should display a
     // real time symbol next to a departure and the type of prediction

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -220,7 +220,7 @@ Realtime positioning information for a given vehicle.
 | **stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Identifies the current stop. The value must be the same as in stops.txt in the corresponding GTFS feed. |
 | **current_status** | [VehicleStopStatus](#enum-vehiclestopstatus) | Optional | One | The exact status of the vehicle with respect to the current stop. Ignored if current_stop_sequence is missing. |
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
-| **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
+| **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One | 
 | _**occupancy_status**_ | _[OccupancyStatus](#enum-occupancystatus)_ | _Optional_ | One | The degree of passenger occupancy of the vehicle.<br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
 
 ## _enum_ VehicleStopStatus
@@ -275,8 +275,8 @@ An alert, indicating some sort of incident in the public transit network.
 |------------------|------------|----------------|-------------------|-------------------|
 | **active_period** | [TimeRange](#message-timerange) | Optional | Many | Time when the alert should be shown to the user. If missing, the alert will be shown as long as it appears in the feed. If multiple ranges are given, the alert will be shown during all of them. |
 | **informed_entity** | [EntitySelector](#message-entityselector) | Required | Many | Entities whose users we should notify of this alert.  At least one informed_entity must be provided. |
-| **cause** | [Cause](#enum-cause) | Optional | One |
-| **effect** | [Effect](#enum-effect) | Optional | One |
+| **cause** | [Cause](#enum-cause) | Optional | One | 
+| **effect** | [Effect](#enum-effect) | Optional | One | 
 | **url** | [TranslatedString](#message-translatedstring) | Optional | One | The URL which provides additional information about the alert. |
 | **header_text** | [TranslatedString](#message-translatedstring) | Required | One | Header for the alert. This plain-text string will be highlighted, for example in boldface. |
 | **description_text** | [TranslatedString](#message-translatedstring) | Required | One | Description for the alert. This plain-text string will be formatted as the body of the alert (or shown on an explicit "expand" request by the user). The information in the description should add to the information of the header. |

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -190,8 +190,8 @@ PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
 | **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
-| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependant on driver behavior. |
-| **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS. This value should be used when changes are due to control action but when the vehicle has not been follwed yet. |
+| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependent on driver behavior. |
+| **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS. This value should be used when changes are due to control action where the applicable schedule is different but when the vehicle has not been followed yet. |
 
 ## _enum_ ScheduleRelationship
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -12,7 +12,7 @@ The following values are used in the *Required* field:
 
 *   **Required**: This field must be provided by a GTFS-realtime feed producer.
 *   **Conditionally required**: This field is required under certain conditions, which are outlined in the field *Description*. Outside of these conditions, the field is optional.
-*   **Optional**: This field is optional and is not required to be implemented by producers. However, if the data is available in the underlying automatic vehicle location systems (e.g., VehiclePosition `timestamp`) it is recommended that producers provide these optional fields when possible. 
+*   **Optional**: This field is optional and is not required to be implemented by producers. However, if the data is available in the underlying automatic vehicle location systems (e.g., VehiclePosition `timestamp`) it is recommended that producers provide these optional fields when possible.
 
 *Note that semantic requirements were not defined in GTFS-realtime version 1.0, and therefore feeds with `gtfs_realtime_version` of `1` may not meet these requirements (see [the proposal for semantic requirements](https://github.com/google/transit/pull/64) for details).*
 
@@ -191,7 +191,7 @@ PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 |-------------|---------------|
 | **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
 | **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing internet connection after the start of the run. |
-| **IMPROVED_SCHEDULE** | Update are based on information from schedule but improved from what is present in the static GTFS. |
+| **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS due to control actions. |
 
 ## _enum_ ScheduleRelationship
 
@@ -220,7 +220,7 @@ Realtime positioning information for a given vehicle.
 | **stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Identifies the current stop. The value must be the same as in stops.txt in the corresponding GTFS feed. |
 | **current_status** | [VehicleStopStatus](#enum-vehiclestopstatus) | Optional | One | The exact status of the vehicle with respect to the current stop. Ignored if current_stop_sequence is missing. |
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
-| **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One | 
+| **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
 | _**occupancy_status**_ | _[OccupancyStatus](#enum-occupancystatus)_ | _Optional_ | One | The degree of passenger occupancy of the vehicle.<br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
 
 ## _enum_ VehicleStopStatus
@@ -275,8 +275,8 @@ An alert, indicating some sort of incident in the public transit network.
 |------------------|------------|----------------|-------------------|-------------------|
 | **active_period** | [TimeRange](#message-timerange) | Optional | Many | Time when the alert should be shown to the user. If missing, the alert will be shown as long as it appears in the feed. If multiple ranges are given, the alert will be shown during all of them. |
 | **informed_entity** | [EntitySelector](#message-entityselector) | Required | Many | Entities whose users we should notify of this alert.  At least one informed_entity must be provided. |
-| **cause** | [Cause](#enum-cause) | Optional | One | 
-| **effect** | [Effect](#enum-effect) | Optional | One | 
+| **cause** | [Cause](#enum-cause) | Optional | One |
+| **effect** | [Effect](#enum-effect) | Optional | One |
 | **url** | [TranslatedString](#message-translatedstring) | Optional | One | The URL which provides additional information about the alert. |
 | **header_text** | [TranslatedString](#message-translatedstring) | Required | One | Header for the alert. This plain-text string will be highlighted, for example in boldface. |
 | **description_text** | [TranslatedString](#message-translatedstring) | Required | One | Description for the alert. This plain-text string will be formatted as the body of the alert (or shown on an explicit "expand" request by the user). The information in the description should add to the information of the header. |

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -190,7 +190,7 @@ PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
 | **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
-| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependent on driver behavior. |
+| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependent on driver behavior. This value should be used when the prediction is not precise enough to show the real time indicator next to the predictions in other interfaces (ex bus stop displays) but that still have information based on real time condition. |
 | **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS. This value should be used when changes are due to control action where the applicable schedule is different but when the vehicle has not been followed yet. |
 
 ## _enum_ ScheduleRelationship

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -177,6 +177,21 @@ The update is linked to a specific stop either through stop_sequence or stop_id,
 | **arrival** | [StopTimeEvent](#message-stoptimeevent) | Conditionally required | One | If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED.  If schedule_relationship is NO_DATA, arrival and departure must be empty. |
 | **departure** | [StopTimeEvent](#message-stoptimeevent) | Conditionally required | One | If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED.  If schedule_relationship is NO_DATA, arrival and departure must be empty. |
 | **schedule_relationship** | [ScheduleRelationship](#enum-schedulerelationship) | Optional | One | The default relationship is SCHEDULED. |
+| **prediction_type** | [PredictionType](#enum-predictiontype) | Optional | One | The default relationship is REALTIME. |
+
+## _enum_ PredictionType
+
+Experimental feild, subject to change.
+PredictionType represent the source of data of the prediction. This lets consumer adjust their display of the information depending on the source (for example, with a real time symbol).
+PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
+
+#### Values
+
+| _**Value**_ | _**Comment**_ |
+|-------------|---------------|
+| **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
+| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing internet connection after the start of the run. |
+| **IMPROVED_SCHEDULE** | Update are based on information from schedule but improved from what is present in the static GTFS. |
 
 ## _enum_ ScheduleRelationship
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -181,7 +181,7 @@ The update is linked to a specific stop either through stop_sequence or stop_id,
 
 ## _enum_ PredictionType
 
-Experimental feild, subject to change.
+Experimental field, subject to change.
 PredictionType represent the source of data of the prediction. This lets consumer adjust their display of the information depending on the source (for example, with a real time symbol).
 PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 
@@ -189,9 +189,9 @@ PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
-| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependent on driver behavior. This value should be used when the prediction is not precise enough to show the real time indicator next to the predictions in other interfaces (ex bus stop displays) but that still have information based on real time condition. |
-| **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS. This value should be used when changes are due to control action where the applicable schedule is different but when the vehicle has not been followed yet. |
+| **REALTIME** | This is the **default** behavior. Updates are based on information from a vehicle that is followed in real time. |
+| **IMPRECISE_REALTIME** | Updates are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependent on driver behavior. This value should be used when the prediction is not precise enough to show the real time indicator next to the predictions in other interfaces (ex bus stop displays) but that still have information based on real time condition. |
+| **UPDATED_SCHEDULE** | Updates are based on information from schedule but updated from what is present in the static GTFS. This value should be used when changes are due to control action where the applicable schedule is different but when the vehicle has not been followed yet. |
 
 ## _enum_ ScheduleRelationship
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -190,8 +190,8 @@ PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
 | **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
-| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run. |
-| **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS due to control actions. |
+| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run, or when a vehicle is a the start of the run but start of the run is dependant on driver behavior. |
+| **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS. This value should be used when changes are due to control action but when the vehicle has not been follwed yet. |
 
 ## _enum_ ScheduleRelationship
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -190,7 +190,7 @@ PredictionType is ignored when schedule_relationship is SKIPPED or NO_DATA.
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
 | **REALTIME** | This is the **default** behavior. Update are based on information from a vehicle that is followed in real time. |
-| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing internet connection after the start of the run. |
+| **IMPRECISE_REALTIME** | Update are based on information from a vehicle that was followed in real time but is imprecise. Imprecision can come from things like a bus losing connection after the start of the run. |
 | **UPDATED_SCHEDULE** | Update are based on information from schedule but updated from what is present in the static GTFS due to control actions. |
 
 ## _enum_ ScheduleRelationship

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -12,7 +12,7 @@ The following values are used in the *Required* field:
 
 *   **Required**: This field must be provided by a GTFS-realtime feed producer.
 *   **Conditionally required**: This field is required under certain conditions, which are outlined in the field *Description*. Outside of these conditions, the field is optional.
-*   **Optional**: This field is optional and is not required to be implemented by producers. However, if the data is available in the underlying automatic vehicle location systems (e.g., VehiclePosition `timestamp`) it is recommended that producers provide these optional fields when possible.
+*   **Optional**: This field is optional and is not required to be implemented by producers. However, if the data is available in the underlying automatic vehicle location systems (e.g., VehiclePosition `timestamp`) it is recommended that producers provide these optional fields when possible. 
 
 *Note that semantic requirements were not defined in GTFS-realtime version 1.0, and therefore feeds with `gtfs_realtime_version` of `1` may not meet these requirements (see [the proposal for semantic requirements](https://github.com/google/transit/pull/64) for details).*
 


### PR DESCRIPTION
Not in this PR but maybe could be done at the same time: deprecation of uncertainty.

An alternative would be to extend `ScheduleRelationship` in `StopTimeUpdate` but that means having `SCHEDULED` (which means real time data) and `IMPRECISE_REALTIME` (real time but imprecise) in the same enum but that seemed not clear enough. 

We put this value on `StopTimeUpdate` because the value could potentially change per stop even if most of the time the value will be the same for all `StopTimeUpdate` in the same `TripUpdate`. 

