### PR TITLE
Simplify enum for occupancy, add occupancy_percentage

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -363,8 +363,8 @@ message VehiclePosition {
     // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
     FEW_SEATS_AVAILABLE = 2 [deprecated=true];
 
-    // The vehicle can currently accommodate only standing passengers.
-    STANDING_ROOM_ONLY = 3;
+    // The vehicle can currently accommodate standing passengers.
+    STANDING_AVAILABLE = 3;
 
     // The vehicle can currently accommodate only standing passengers
     // and has limited space for them.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -384,7 +384,7 @@ message VehiclePosition {
 
   // A percentage value representing the degree of passenger occupancy of the vehicle.
   // The value 100 should represent the total maximum occupancy the vehicle was designed for, including both seated and standing capacity.
-  // It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.
+  // It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.
   optional OccupancyStatus occupancy_percentage = 10;
 
   // The extensions namespace allows 3rd-party developers to extend the

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -349,25 +349,18 @@ message VehiclePosition {
 
   // The degree of passenger occupancy of the vehicle
   enum OccupancyStatus {
-    // The vehicle is considered empty by most measures, and has few or no
-    // passengers onboard, but is still accepting passengers.
+    // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
     EMPTY = 0 [deprecated=true];
 
     // The vehicle has seats available.
     SEATS_AVAILABLE = 1;
 
-    // The vehicle has a relatively small percentage of seats available.
-    // What percentage of free seats out of the total seats available is to be
-    // considered small enough to fall into this category is determined at the
-    // discretion of the feed producer.
     // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
     FEW_SEATS_AVAILABLE = 2 [deprecated=true];
 
     // The vehicle can currently accommodate only standing passengers.
     STANDING_ROOM_ONLY = 3;
 
-    // The vehicle can currently accommodate only standing passengers
-    // and has limited space for them.
     // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
     CRUSHED_STANDING_ROOM_ONLY = 4 [deprecated=true];
 
@@ -375,7 +368,6 @@ message VehiclePosition {
     // allowing passengers to board.
     FULL = 5;
 
-    // The vehicle is not accepting additional passengers.
     // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
     NOT_ACCEPTING_PASSENGERS = 6 [deprecated=true];
 

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -383,6 +383,7 @@ message VehiclePosition {
   optional OccupancyStatus occupancy_status = 9;
 
   // A percentage value representing the degree of passenger occupancy of the vehicle.
+  // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
   // The value 100 should represent the total maximum occupancy the vehicle was designed for, including both seated and standing capacity.
   // It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.
   optional OccupancyStatus occupancy_percentage = 10;

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -386,6 +386,7 @@ message VehiclePosition {
   // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
   // The value 100 should represent the total maximum occupancy the vehicle was designed for, including both seated and standing capacity.
   // It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.
+  // The precision of precision should be low enough that you can't track a single person boarding and alighting for privacy reasons.
   optional OccupancyStatus occupancy_percentage = 10;
 
   // The extensions namespace allows 3rd-party developers to extend the

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -383,7 +383,7 @@ message VehiclePosition {
   optional OccupancyStatus occupancy_status = 9;
 
   // A percentage value representing the degree of passenger occupancy of the vehicle.
-  // The value 100 should represent total the maximum occupancy the vehicle was designed for.
+  // The value 100 should represent the total maximum occupancy the vehicle was designed for, including both seated and standing capacity.
   // It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.
   optional OccupancyStatus occupancy_percentage = 10;
 

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -347,42 +347,45 @@ message VehiclePosition {
   }
   optional CongestionLevel congestion_level = 6;
 
-  // The degree of passenger occupancy of the vehicle. This field is still
-  // experimental, and subject to change. It may be formally adopted in the
-  // future.
+  // The degree of passenger occupancy of the vehicle
   enum OccupancyStatus {
     // The vehicle is considered empty by most measures, and has few or no
     // passengers onboard, but is still accepting passengers.
-    EMPTY = 0;
+    EMPTY = 0 [deprecated=true];
 
-    // The vehicle has a relatively large percentage of seats available.
-    // What percentage of free seats out of the total seats available is to be
-    // considered large enough to fall into this category is determined at the
-    // discretion of the producer.
-    MANY_SEATS_AVAILABLE = 1;
+    // The vehicle has seats available.
+    SEATS_AVAILABLE = 1;
 
     // The vehicle has a relatively small percentage of seats available.
     // What percentage of free seats out of the total seats available is to be
     // considered small enough to fall into this category is determined at the
     // discretion of the feed producer.
-    FEW_SEATS_AVAILABLE = 2;
+    // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
+    FEW_SEATS_AVAILABLE = 2 [deprecated=true];
 
     // The vehicle can currently accommodate only standing passengers.
     STANDING_ROOM_ONLY = 3;
 
     // The vehicle can currently accommodate only standing passengers
     // and has limited space for them.
-    CRUSHED_STANDING_ROOM_ONLY = 4;
+    // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
+    CRUSHED_STANDING_ROOM_ONLY = 4 [deprecated=true];
 
     // The vehicle is considered full by most measures, but may still be
     // allowing passengers to board.
     FULL = 5;
 
     // The vehicle is not accepting additional passengers.
-    NOT_ACCEPTING_PASSENGERS = 6;
+    // Deprecated, if you need more granularity than the available enum please use occupancy_percentage
+    NOT_ACCEPTING_PASSENGERS = 6 [deprecated=true];
 
   }
   optional OccupancyStatus occupancy_status = 9;
+
+  // A percentage value representing the degree of passenger occupancy of the vehicle.
+  // The value 100 should represent total the maximum occupancy the vehicle was designed for.
+  // It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.
+  optional OccupancyStatus occupancy_percentage = 10;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -208,7 +208,7 @@ Realtime positioning information for a given vehicle.
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
 | **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The degree of passenger occupancy of the vehicle. More detail can be provided with _occupancy_percentage_. |
-| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for including both seating and standing capacity. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
+| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for including both seating and standing capacity. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for. The precision of precision should be low enough that you can't track a single person boarding and alighting for privacy reasons. |
 
 ## _enum_ VehicleStopStatus
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -208,7 +208,7 @@ Realtime positioning information for a given vehicle.
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
 | **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The degree of passenger occupancy of the vehicle. More detail can be provided with _occupancy_percentage_. |
-| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
+| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for including both seating and standing capacity. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
 
 ## _enum_ VehicleStopStatus
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -243,7 +243,7 @@ The degree of passenger occupancy for the vehicle. OccupancyStatus should be use
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
 | _**SEATS_AVAILABLE**_ | _The vehicle has seats available._ |
-| _**STANDING_ROOM_ONLY**_ | _The vehicle can currently accommodate only standing passengers._ |
+| _**STANDING_AVAILABLE**_ | _The vehicle can currently accommodate standing passengers._ |
 | _**FULL**_ | _The vehicle is considered full by most measures, but may still be allowing passengers to board._ |
 
 ## _message_ Alert

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -208,7 +208,7 @@ Realtime positioning information for a given vehicle.
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
 | **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The degree of passenger occupancy of the vehicle. More detail can be provided with _occupancy_percentage_. |
-| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for including both seating and standing capacity. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
+| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent the total maximum occupancy the vehicle was designed for including both seating and standing capacity. It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.  |
 
 ## _enum_ VehicleStopStatus
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -208,7 +208,7 @@ Realtime positioning information for a given vehicle.
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
 | **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The degree of passenger occupancy of the vehicle. More detail can be provided with _occupancy_percentage_. |
-| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optionals | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
+| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
 
 ## _enum_ VehicleStopStatus
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -208,7 +208,7 @@ Realtime positioning information for a given vehicle.
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
 | **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The degree of passenger occupancy of the vehicle. More detail can be provided with _occupancy_percentage_. |
-| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent the total maximum occupancy the vehicle was designed for including both seating and standing capacity. It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.  |
+| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for including both seating and standing capacity. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
 
 ## _enum_ VehicleStopStatus
 
@@ -236,7 +236,7 @@ Congestion level that is affecting this vehicle.
 
 ## _enum OccupancyStatus_
 
-The degree of passenger occupancy for the vehicle. OccupancyStatus should be used to display a textual or
+The degree of passenger occupancy for the vehicle. OccupancyStatus should be used to display a textual or iconic representation of occupancy
 
 #### _Values_
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -207,7 +207,8 @@ Realtime positioning information for a given vehicle.
 | **current_status** | [VehicleStopStatus](#enum-vehiclestopstatus) | Optional | One | The exact status of the vehicle with respect to the current stop. Ignored if current_stop_sequence is missing. |
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
-| _**occupancy_status**_ | _[OccupancyStatus](#enum-occupancystatus)_ | _Optional_ | One | The degree of passenger occupancy of the vehicle.<br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
+| **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The degree of passenger occupancy of the vehicle. More detail can be provided with _occupancy_percentage_. |
+| **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optionals | One | A percentage value representing the degree of passenger occupancy of the vehicle. The value 100 should represent total the maximum occupancy the vehicle was designed for. It's not impossible that the value goes over 100 if there are currently more passenger than the vehicle was designed for.  |
 
 ## _enum_ VehicleStopStatus
 
@@ -235,21 +236,15 @@ Congestion level that is affecting this vehicle.
 
 ## _enum OccupancyStatus_
 
-The degree of passenger occupancy for the vehicle.
-
-**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
+The degree of passenger occupancy for the vehicle. OccupancyStatus should be used to display a textual or
 
 #### _Values_
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| _**EMPTY**_ | _The vehicle is considered empty by most measures, and has few or no passengers onboard, but is still accepting passengers._ |
-| _**MANY_SEATS_AVAILABLE**_ | _The vehicle has a large percentage of seats available. What percentage of free seats out of the total seats available is to be considered large enough to fall into this category is determined at the discretion of the producer._ |
-| _**FEW_SEATS_AVAILABLE**_ | _The vehicle has a small percentage of seats available. What percentage of free seats out of the total seats available is to be considered small enough to fall into this category is determined at the discretion of the producer._ |
+| _**SEATS_AVAILABLE**_ | _The vehicle has seats available._ |
 | _**STANDING_ROOM_ONLY**_ | _The vehicle can currently accommodate only standing passengers._ |
-| _**CRUSHED_STANDING_ROOM_ONLY**_ | _The vehicle can currently accommodate only standing passengers and has limited space for them._ |
 | _**FULL**_ | _The vehicle is considered full by most measures, but may still be allowing passengers to board._ |
-| _**NOT_ACCEPTING_PASSENGERS**_ | _The vehicle can not accept passengers._ |
 
 ## _message_ Alert
 
@@ -359,7 +354,7 @@ To specify a single trip instance, in many cases a `trip_id` by itself is suffic
 * If the trip lasts for more than 24 hours, or is delayed such that it would collide with a scheduled trip on the following day, then `start_date` is required in addition to `trip_id`
 * If the `trip_id` field can't be provided, then `route_id`, `direction_id`, `start_date`, and `start_time` must all be provided
 
-In all cases, if `route_id` is provided in addition to `trip_id`, then the `route_id` must be the same `route_id` as assigned to the given trip in GTFS trips.txt. 
+In all cases, if `route_id` is provided in addition to `trip_id`, then the `route_id` must be the same `route_id` as assigned to the given trip in GTFS trips.txt.
 
 The `trip_id` field cannot, by itself or in combination with other TripDescriptor fields, be used to identify multiple trip instances. For example, a TripDescriptor should never specify trip_id by itself for GTFS frequencies.txt exact_times=0 trips because start_time is also required to resolve to a single trip instance starting at a specific time of the day. If the TripDescriptor does not resolve to a single trip instance (i.e., it resolves to zero or multiple trip instances), it is considered an error and the entity containing the erroneous TripDescriptor may be discarded by consumers.
 


### PR DESCRIPTION
OccupancyStatus was added 6 years ago as an experimental field to the GTFS-rt spec. Multiple producers and consumers have adopted the value but the implementation has currently some problems. 

The enum of `occupancy_status` has 7 values, however we've seen that the range of values is not used in practice. We've seen consumer mostly use 3 values to represent the entire range of occupancy. For example : 
- New South Wales buses only use the `MANY_SEATS_AVAILABLE`, `FEW_SEATS_AVAILABLE` and `STANDING_ROOM_ONLY`. 
- Some New South Wales trains uses all the values available except `EMPTY` and `NOT_ACCEPTING_PASSENGERS`. However, the agency suggest to never display more than 3 textual values for the consumer facing message. More granularity can be provided with colors. 
- MTA NYC has limited availability of the feature in their feed but do use `FEW_SEATS_AVAILABLE`, `STANDING_ROOM_ONLY`, `FULL`. 

For this reason I would suggest to only give 3 values in the enum. `FEW_SEATS_AVAILABLE`, `STANDING_AVAILABLE`, `FULL`. The naming changed slightly to reflect the same 3 values available in SIRI. 

However, we do lose a lot of granularity of how fine the occupancy value can be provided. To alleviate this problem I would suggest to add a second value `occupancy_percentage` to give a more accurate value of occupancy. 

It would be percentage value representing the degree of passenger occupancy of the vehicle. The values are represented as an integer without decimals. 0 means 0% and 100 means 100%. The value 100 should represent the total maximum occupancy the vehicle was designed for, including both seated and standing capacity. It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.

It was decided to have both values because they fulfill two different purpose. `occupancy_status` is provided to give a understandable value for the user (`STANDING_ROOM_ONLY` is way more understandable for a user than 50% full). `occupancy_percentage` is provided to give more granular data. 