### PR TITLE
Option A : Use stop_id as optional selector in addition to stop sequence

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1075,19 +1075,24 @@ message Stop {
 message TripModifications {
 	message Modification {
     // The first stop sequence of the original trip that is to be affected by this modification.
+    // At least one of start_stop_sequence or start_stop_id must be provided
 		optional uint32 start_stop_sequence = 1;
 
+    // The first stop of the original trip that is to be affected by this modification.
+    // At least one of start_stop_sequence or start_stop_id must be provided
+    optional string start_stop_id = 2;
+
     // The number of stops which are canceled and replaced by the replacement_stops. May be zero to indicate no skipped stops.
-		optional uint32 num_stops_replaced = 2;
+		optional uint32 num_stops_replaced = 3;
 
     // The number of seconds of delay to add to all departure and arrival times following the end of this modification. If multiple modifications apply to the same trip, the delays accumulate as the trip advances. 
-		optional int32 propagated_modification_delay = 3 [default = 0];
+		optional int32 propagated_modification_delay = 4 [default = 0];
 
     // A list of replacement stops, replacing those of the original trip. The length of the new stop times may be less, the same, or greater than the number of replaced stop times. 
-		repeated ReplacementStop replacement_stops = 4;
+		repeated ReplacementStop replacement_stops = 5;
 
     // An `id` value from the `FeedEntity` message that contains the `Alert` describing this Modification for user-facing communication.
-    optional string service_alert_id = 5;
+    optional string service_alert_id = 6;
 
 		// The extensions namespace allows 3rd-party developers to extend the
 		// GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1103,7 +1103,10 @@ message TripModifications {
 		extensions 9000 to 9999;
 	}
 
-   // A list of trips affected by this detour. All trips linked by those trip_ids MUST have the same stop pattern. Two trips have the same stop pattern, if they visit the same stops in the same order, and have identical stop sequences.
+   // A list of trips affected by this detour. 
+   // If `start_stop_sequence` is used to target the start of the modificaiton, all trips linked by those trip_ids MUST have the same stop pattern. 
+   // Two trips have the same stop pattern, if they visit the same stops in the same order, and have identical stop sequences.
+   // If `start_stop_id` is used to target the start of the modification, the stop pattern of the trips is not required to be the same.
   repeated string trip_ids = 2;
 
   // Dates on which the detour occurs, in the YYYYMMDD format. Producers SHOULD only transmit detours occurring within the next week.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1104,9 +1104,7 @@ message TripModifications {
 	}
 
    // A list of trips affected by this detour. 
-   // If `start_stop_sequence` is used to target the start of the modificaiton, all trips linked by those trip_ids MUST have the same stop pattern. 
-   // Two trips have the same stop pattern, if they visit the same stops in the same order, and have identical stop sequences.
-   // If `start_stop_id` is used to target the start of the modification, the stop pattern of the trips is not required to be the same.
+   // The specified trip_ids must match at the intervals specified by the modifications, whether specified by stop sequence and count, or by stop ID and count.
   repeated string trip_ids = 2;
 
   // Dates on which the detour occurs, in the YYYYMMDD format. Producers SHOULD only transmit detours occurring within the next week.


### PR DESCRIPTION
Add a way to target modifications with stop_id and make the stop pattern requirement conditionally required. 

Note that only the `gtfs-realtime.proto` file is updated. If that option is selected, more changes to `references.md` and `trip-modifications.md` will be required.