### PR TITLE
Add optional carriage_positions.txt specification

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -35,6 +35,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [frequencies.txt](#frequenciestxt)
     -   [transfers.txt](#transferstxt)
     -   [pathways.txt](#pathwaystxt)
+    -   [carriage_positions.txt](#carriage_positionstxt)
     -   [levels.txt](#levelstxt)
     -   [location_groups.txt](#location_groupstxt)
     -   [location_group_stops.txt](#location_group_stopstxt)
@@ -139,6 +140,7 @@ This specification defines the following files:
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for headway-based service or a compressed representation of fixed-schedule service. |
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
 |  [pathways.txt](#pathwaystxt)  | Optional | Pathways linking together locations within stations. |
+|  [carriage_positions.txt](#carriage_positionstxt)  | Optional | Optimal carriage positioning for transfers and platform exits. |
 |  [levels.txt](#levelstxt)  | **Conditionally Required** | Levels within stations.<br><br>Conditionally Required:<br>- **Required** when describing pathways with elevators (`pathway_mode=5`).<br>- Optional otherwise. |
 |  [location_groups.txt](#location_groupstxt)  | Optional | A group of stops that together indicate locations where a rider may request pickup or drop off. |
 |  [location_group_stops.txt](#location_group_stopstxt)  | Optional | Rules to assign stops to location groups. |
@@ -746,6 +748,27 @@ Pathways are intended to exhaustively define the internal access graph of a stat
 | `min_width` | Positive float | Optional | Minimum width of the pathway in meters.<br><br>This field is recommended if the minimum width is less than 1 meter.|
 | `signposted_as` | Text | Optional | Public facing text from physical signage that is visible to riders.<br><br> May be used to provide text directions to riders, such as 'follow signs to '. The text in `singposted_as` should appear exactly how it is printed on the signs.<br><br>When the physical signage is multilingual, this field may be populated and translated following the example of `stops.stop_name` in the field definition of `feed_info.feed_lang`.|
 | `reversed_signposted_as` | Text | Optional | Same as `signposted_as`, but when the pathway is used from the `to_stop_id` to the `from_stop_id`.|
+
+### carriage_positions.txt
+
+File: **Optional**
+
+Primary key (`from_stop_id`, `to_stop_id`, `facility_type`)
+
+Defines optimal carriage positioning for transfers and platform exit access. Enables trip planners to recommend which carriage passengers should board to minimize walking time at their destination.
+
+While [pathways.txt](#pathwaystxt) handles navigation within stations, it does not address where to stand on the platform before boarding. This file complements pathways by providing carriage-level boarding recommendations.
+
+Producers MAY use logical carriage divisions when exact carriage positions are unavailable. For example, `carriage_count=3` with `recommended_carriage=1` indicates "board near the front" regardless of actual vehicle length.
+
+|  Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+|  `from_stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the platform where the passenger boards. Must reference a stop with `location_type=0`. |
+|  `to_stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the destination: a transfer platform, station entrance, or exit. Must reference a stop with `location_type=0` or `location_type=2`. |
+|  `recommended_carriage` | Non-negative integer | **Required** | The recommended carriage to board, 1-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than or equal to `carriage_count`. |
+|  `carriage_count` | Non-negative integer | **Required** | Number of carriage positions in this configuration. May represent logical divisions (e.g., 3 for front/middle/back) rather than actual carriage count. |
+|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
+|  `facility_type` | Enum | Optional | Type of facility at the destination. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
 
 ### levels.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -35,6 +35,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [frequencies.txt](#frequenciestxt)
     -   [transfers.txt](#transferstxt)
     -   [pathways.txt](#pathwaystxt)
+    -   [station_directions.txt](#station_directionstxt)
     -   [carriage_positions.txt](#carriage_positionstxt)
     -   [levels.txt](#levelstxt)
     -   [location_groups.txt](#location_groupstxt)
@@ -140,6 +141,7 @@ This specification defines the following files:
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for headway-based service or a compressed representation of fixed-schedule service. |
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
 |  [pathways.txt](#pathwaystxt)  | Optional | Pathways linking together locations within stations. |
+|  [station_directions.txt](#station_directionstxt)  | Optional | Platform direction of the front carriage at each stop. |
 |  [carriage_positions.txt](#carriage_positionstxt)  | Optional | Optimal carriage positioning for transfers and platform exits. |
 |  [levels.txt](#levelstxt)  | **Conditionally Required** | Levels within stations.<br><br>Conditionally Required:<br>- **Required** when describing pathways with elevators (`pathway_mode=5`).<br>- Optional otherwise. |
 |  [location_groups.txt](#location_groupstxt)  | Optional | A group of stops that together indicate locations where a rider may request pickup or drop off. |
@@ -749,11 +751,24 @@ Pathways are intended to exhaustively define the internal access graph of a stat
 | `signposted_as` | Text | Optional | Public facing text from physical signage that is visible to riders.<br><br> May be used to provide text directions to riders, such as 'follow signs to '. The text in `singposted_as` should appear exactly how it is printed on the signs.<br><br>When the physical signage is multilingual, this field may be populated and translated following the example of `stops.stop_name` in the field definition of `feed_info.feed_lang`.|
 | `reversed_signposted_as` | Text | Optional | Same as `signposted_as`, but when the pathway is used from the `to_stop_id` to the `from_stop_id`.|
 
+### station_directions.txt
+
+File: **Optional**
+
+Primary key (`stop_id`)
+
+Defines which side of the platform the front carriage stops at. This information is used alongside [carriage_positions.txt](#carriage_positionstxt) to determine boarding recommendations. When the departure and arrival stations have different front car directions, trip planners can mirror the recommended carriage accordingly.
+
+|  Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+|  `stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the platform. Must reference a stop with `location_type=0`. |
+|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
+
 ### carriage_positions.txt
 
 File: **Optional**
 
-Primary key (`from_stop_id`, `to_stop_id`, `facility_type`)
+Primary key (`stop_id`, `to_stop_id`, `facility_type`)
 
 Defines optimal carriage positioning for transfers and platform exit access. Enables trip planners to recommend which carriage passengers should board to minimize walking time at their destination.
 
@@ -763,12 +778,11 @@ Producers MAY use logical carriage divisions when exact carriage positions are u
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
-|  `from_stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the platform where the passenger boards. Must reference a stop with `location_type=0`. |
-|  `to_stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the destination: a transfer platform, station entrance, or exit. Must reference a stop with `location_type=0` or `location_type=2`. |
-|  `recommended_carriage` | Non-negative integer | **Required** | The recommended carriage to board, 1-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than or equal to `carriage_count`. |
-|  `carriage_count` | Non-negative integer | **Required** | Number of carriage positions in this configuration. May represent logical divisions (e.g., 3 for front/middle/back) rather than actual carriage count. |
-|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops at `from_stop_id`, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
-|  `facility_type` | Enum | Optional | Type of facility available close to the recommended carriage with destination `to_stop_id`. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
+|  `stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the arrival platform. Must reference a stop with `location_type=0`. |
+|  `to_stop_id` | Foreign ID referencing `stops.stop_id` | Optional | Identifies a specific destination: a transfer platform, station entrance, or exit. Must reference a stop with `location_type=0` or `location_type=2`. When empty, the recommendation applies as a general default for the station. When provided, it gives a destination-specific recommendation that takes priority over the general default. |
+|  `recommended_carriage` | Positive integer | **Required** | The recommended carriage to board, 1-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than or equal to `carriage_count`. |
+|  `carriage_count` | Positive integer | **Required** | Number of carriage positions in this configuration. May represent logical divisions (e.g., 3 for front/middle/back) rather than actual carriage count. |
+|  `facility_type` | Enum | Optional | Type of facility available close to the recommended carriage. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
 
 ### levels.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -768,7 +768,7 @@ Producers MAY use logical carriage divisions when exact carriage positions are u
 |  `recommended_carriage` | Non-negative integer | **Required** | The recommended carriage to board, 1-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than or equal to `carriage_count`. |
 |  `carriage_count` | Non-negative integer | **Required** | Number of carriage positions in this configuration. May represent logical divisions (e.g., 3 for front/middle/back) rather than actual carriage count. |
 |  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops at `from_stop_id`, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
-|  `facility_type` | Enum | Optional | Type of facility available close to the recommended carriage at with destination `to_stop_id`. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
+|  `facility_type` | Enum | Optional | Type of facility available close to the recommended carriage with destination `to_stop_id`. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
 
 ### levels.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -767,8 +767,8 @@ Producers MAY use logical carriage divisions when exact carriage positions are u
 |  `to_stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the destination: a transfer platform, station entrance, or exit. Must reference a stop with `location_type=0` or `location_type=2`. |
 |  `recommended_carriage` | Non-negative integer | **Required** | The recommended carriage to board, 1-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than or equal to `carriage_count`. |
 |  `carriage_count` | Non-negative integer | **Required** | Number of carriage positions in this configuration. May represent logical divisions (e.g., 3 for front/middle/back) rather than actual carriage count. |
-|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
-|  `facility_type` | Enum | Optional | Type of facility at the destination. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
+|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops at `from_stop_id`, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
+|  `facility_type` | Enum | Optional | Type of facility available close to the recommended carriage at with destination `to_stop_id`. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
 
 ### levels.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -762,7 +762,7 @@ Defines which side of the platform the front carriage stops at. This information
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
 |  `stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the platform. Must reference a stop with `location_type=0`. |
-|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 1) stops, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
+|  `front_car_position` | Enum | **Required** | Platform side where the front carriage (carriage 0) stops, from the perspective of a passenger facing the track. Valid options are:<br><br>`left` - Front carriage stops on the left side of the platform.<br>`right` - Front carriage stops on the right side of the platform. |
 
 ### carriage_positions.txt
 
@@ -774,13 +774,13 @@ Defines optimal carriage positioning for transfers and platform exit access. Ena
 
 While [pathways.txt](#pathwaystxt) handles navigation within stations, it does not address where to stand on the platform before boarding. This file complements pathways by providing carriage-level boarding recommendations.
 
-Producers MAY use logical carriage divisions when exact carriage positions are unavailable. For example, `carriage_count=3` with `recommended_carriage=1` indicates "board near the front" regardless of actual vehicle length.
+Producers MAY use logical carriage divisions when exact carriage positions are unavailable. For example, `carriage_count=3` with `recommended_carriage=0` indicates "board near the front" regardless of actual vehicle length.
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
 |  `stop_id` | Foreign ID referencing `stops.stop_id` | **Required** | Identifies the arrival platform. Must reference a stop with `location_type=0`. |
 |  `to_stop_id` | Foreign ID referencing `stops.stop_id` | Optional | Identifies a specific destination: a transfer platform, station entrance, or exit. Must reference a stop with `location_type=0` or `location_type=2`. When empty, the recommendation applies as a general default for the station. When provided, it gives a destination-specific recommendation that takes priority over the general default. |
-|  `recommended_carriage` | Positive integer | **Required** | The recommended carriage to board, 1-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than or equal to `carriage_count`. |
+|  `recommended_carriage` | Non-negative integer | **Required** | The recommended carriage to board, 0-indexed from the front of the vehicle. May represent a logical position rather than exact carriage number. Must be less than `carriage_count`. |
 |  `carriage_count` | Positive integer | **Required** | Number of carriage positions in this configuration. May represent logical divisions (e.g., 3 for front/middle/back) rather than actual carriage count. |
 |  `facility_type` | Enum | Optional | Type of facility available close to the recommended carriage. Valid options are:<br><br>`elevator` - Elevator access.<br>`escalator` - Escalator access.<br>`stairs` - Stair access.<br><br>May be empty if the destination is another platform or general exit. |
 


### PR DESCRIPTION
This proposal adds a new optional file carriage_positions.txt that defines optimal carriage positioning for transfers and platform exit access. It enables trip planners to recommend which carriage passengers should board to minimize walking time at transfer points and alighting stations.

## Motivation 

There is at least one example of this type of public data in production, but it does not use a standardized format: Île-de-France Mobilités [publishes carriage positioning data for the Paris métro](https://prim.iledefrance-mobilites.fr/en/jeux-de-donnees/positionnement-dans-la-rame), and Transit ingests this information from IDFM.

While pathways.txt handles navigation within stations, it does not address where to stand on the platform before boarding. This file complements pathways by providing carriage-level boarding recommendations, including information about where passengers should board a vehicle to most easily access stairs, escalators, and elevators at transfer points and alighting stations.

Transit also supports displaying this information based upon crowdsourced data collected through its own app. Receiving carriage position information directly from producers in a standardized format within GTFS would improve data reliability and be beneficial to the entire ecosystem.

<img width="346" height="352.5" alt="image" src="https://github.com/user-attachments/assets/5dbe8860-a3f7-4762-a0bb-0df8f1188ed4" />


## Proposed Solution
Add a `carriage_positions.txt` containing the recommended carriage for boarding, based on a carriage count, for each from/to stop id pair. 

## Type of change

GTFS Schedule Functional Change

## Proposed Discussion Period
<!--Please specify a minimum estimated discussion period length based on the scope of the proposed change.* 
- *Example: “I recommend reserving at least one month for discussion to ensure everyone has sufficient time to discuss the proposal.”-->

## Testing Details
<!--If applicable, confirm the identity of the Consumer(s) and Producer(s) who will test the changes in the Pull Request comment section and document them below.-->

- Consumer(s): <!--List the entities that will consume the data and test the proposed change.-->
- Producer(s): <!--List the entities that will produce the data and test the proposed change.-->
- Estimated Testing Period: <!--Specify the duration for testing.-->

## Proposal Update Tracker 

| Date       | Update Description |
|------------|--------------------|
| (YYYY-MM-DD) | (Brief description of the update) |
